### PR TITLE
Add rules for accessing HID devices with libusb

### DIFF
--- a/41-nitrokey.rules
+++ b/41-nitrokey.rules
@@ -9,18 +9,24 @@ ACTION!="add|change", GOTO="u2f_end"
 
 # Nitrokey U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="f1d0", TAG+="uaccess"
 # Nitrokey FIDO U2F
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4287", TAG+="uaccess"
 # Nitrokey FIDO2
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b1", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b1", TAG+="uaccess"
 # Nitrokey 3A Mini/3A NFC/3C NFC
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b2", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42b2", TAG+="uaccess"
 # Nitrokey 3A NFC Bootloader/3C NFC Bootloader
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42dd", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42dd", TAG+="uaccess"
 # Nitrokey 3A Mini Bootloader
 ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42e8", TAG+="uaccess"
 # Nitrokey Passkey
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42f3", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42f3", TAG+="uaccess"
 # Nitrokey Passkey Bootloader
 ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="42f4", TAG+="uaccess"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove symlink rule for the Nitrokey Storage.  Users are advised to use
   label- or UUID-based mounting or setup a a custom rule for their device
   instead.
+- Add rules for accessing HID devices with libusb.
 
 ## [v1.0.0][] (2024-01-29)
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ check:
 .PHONY: fix
 fix:
 	$(RUFF) check --fix
-	$(PYRIGHT) format
+	$(RUFF) format
 
 .PHONY: generate
 generate:

--- a/devices.toml
+++ b/devices.toml
@@ -2,31 +2,31 @@
 name = "Nitrokey U2F"
 vid = 0x2581
 pid = 0xf1d0
-hidraw = true
+hid = true
 
 [[u2f]]
 name = "Nitrokey FIDO U2F"
 vid = 0x20a0
 pid = 0x4287
-hidraw = true
+hid = true
 
 [[u2f]]
 name = "Nitrokey FIDO2"
 vid = 0x20a0
 pid = 0x42b1
-hidraw = true
+hid = true
 
 [[u2f]]
 name = "Nitrokey 3A Mini/3A NFC/3C NFC"
 vid = 0x20a0
 pid = 0x42b2
-hidraw = true
+hid = true
 
 [[u2f]]
 name = "Nitrokey 3A NFC Bootloader/3C NFC Bootloader"
 vid = 0x20a0
 pid = 0x42dd
-hidraw = true
+hid = true
 
 [[u2f]]
 name = "Nitrokey 3A Mini Bootloader"
@@ -38,7 +38,7 @@ all = true
 name = "Nitrokey Passkey"
 vid = 0x20a0
 pid = 0x42f3
-hidraw = true
+hid = true
 
 [[u2f]]
 name = "Nitrokey Passkey Bootloader"

--- a/generate.py
+++ b/generate.py
@@ -10,7 +10,7 @@ class Device:
     name: str
     vid: int
     pid: int
-    hidraw: bool = False
+    hid: bool = False
     gnupg: bool = False
     all: bool = False
 
@@ -25,12 +25,13 @@ class Device:
             ("ATTRS{idProduct}", "==", f"{self.pid:04x}"),
         ]
         uaccess = [("TAG", "+=", "uaccess")]
-        if self.hidraw:
+        if self.hid:
             s += generate_rule(
                 [("KERNEL", "==", "hidraw*"), ("SUBSYSTEM", "==", "hidraw")]
                 + attrs_vid_pid
                 + uaccess
             )
+            s += generate_rule([("SUBSYSTEMS", "==", "usb")] + attrs_vid_pid + uaccess)
         if self.gnupg:
             s += generate_rule(
                 attr_vid_pid


### PR DESCRIPTION
HID devices can be accessed with libusb or with hidraw.  So far, we have mostly been using hidraw and our udev rules only apply to hidraw devices.  This patch adds rules for access with libusb as recommended by the hidapi developers:

https://github.com/libusb/hidapi/blob/ff67c77daddbd8e61ad3873ac16f8edc005f943f/udev/69-hid.rules

----

You can use the following code for testing:

```python
import hid

devices = hid.enumerate()
print("paths: ")
print([d["path"] for d in devices])

for device in devices:
    if device["vendor_id"] == 0x20a0 and device["product_id"] == 0x42dd:
        h = hid.device()
        h.open_path(device["path"])
        h.close()
```

With hidapi v0.14.0 and v0.14.0.post4, this uses libusb.  With hidapi v0.14.0.post1 to v0.14.0.post3, this uses hidraw.  (This only applies if hidapi is installed from the PyPI wheels – packaged versions or manual builds may behave differently.)  From my experience, a reboot is required to properly apply the new rules.