### PR TITLE
Remove symlink rule for the Nitrokey Storage

### DIFF
--- a/41-nitrokey.rules
+++ b/41-nitrokey.rules
@@ -46,7 +46,3 @@ ATTR{idVendor}=="20a0", ATTR{idProduct}=="4211", ENV{ID_SMARTCARD_READER}="1", E
 ATTR{idVendor}=="20a0", ATTR{idProduct}=="4230", ENV{ID_SMARTCARD_READER}="1", ENV{ID_SMARTCARD_READER_DRIVER}="gnupg", TAG+="uaccess"
 
 LABEL="gnupg_rules_end"
-
-
-# Nitrokey Storage dev Entry
-KERNEL=="sd?1", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4109", SYMLINK+="nitrospace"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Remove symlink rule for the Nitrokey Storage.  Users are advised to use
+  label- or UUID-based mounting or setup a a custom rule for their device
+  instead.
+
 ## [v1.0.0][] (2024-01-29)
 
 [v1.0.0]: https://github.com/Nitrokey/nitrokey-udev-rules/releases/tag/v1.0.0

--- a/generate.py
+++ b/generate.py
@@ -95,12 +95,6 @@ def generate(u2f_devices: list[Device], ccid_devices: list[Device]) -> str:
 
     output = textwrap.dedent(header)
     output += "\n\n".join(sections)
-    # TODO: can we remove this?
-    output += textwrap.dedent("""
-
-        # Nitrokey Storage dev Entry
-        KERNEL=="sd?1", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4109", SYMLINK+="nitrospace"
-    """)
     return output
 
 


### PR DESCRIPTION
See the discussion in https://github.com/Nitrokey/nitrokey-udev-rules/pull/5.