### PR TITLE
Add more details about uaccess to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,34 @@ The rules use the `uaccess` tag which is a systemd mechanism.
 
 To install the rules file, place it in `/etc/udev/rules.d`.
 The file prefix should be lower than 73 because the rules must be applied before udev’s `73-seat-late.rules`.
+
+## Troubleshooting
+
+### Check device permissions
+
+`uaccess` grants permissions to all local users via an ACL.
+Use `getfacl` to check that the permissions are set correctly, for example:
+
+```
+$ getfacl /dev/hidraw0
+getfacl: Removing leading '/' from absolute path names
+# file: dev/hidraw0
+# owner: root
+# group: root
+user::rw-
+user:robin:rw-
+group::---
+mask::rw-
+other::---
+```
+
+Here, the line `user:robin:rw-` indicates that the user `robin` has access to the device.
+
+### Grant access to remote users
+
+`uaccess` only grants access to local users.
+Remote users, for example via SSH, will not have access to the devices with these rules.
+If you want to allow remote users to use a device, you have to modify the rules and set the `MODE` or `OWNER` variables.
+See [udev(7)][] for more information.
+
+[udev(7)]: https://www.freedesktop.org/software/systemd/man/latest/udev.html


### PR DESCRIPTION
This patch extends the readme to add more details about uaccess, namely how the permissions can be checked and that it only applies to local users.